### PR TITLE
Remove delegate to localhost

### DIFF
--- a/tasks/autoregistration.yml
+++ b/tasks/autoregistration.yml
@@ -22,7 +22,6 @@
     http_method: get
     path: "cloud?name={{ se_cloud_name }}"
   register: se_cloud_data
-  delegate_to: localhost
 
 - name: Avi SE | Autoregistration | Get the cluster uuid from /api/cluster/status
   avi_api_session:
@@ -34,7 +33,6 @@
     http_method: get
     path: "cluster/status"
   register: se_cluster_data
-  delegate_to: localhost
 
 - name: Avi SE | Autoregistration | Get a token from the Avi Controller
   avi_api_session:
@@ -46,7 +44,6 @@
     http_method: get
     path: securetoken-generate?cloud_uuid={{ se_cloud_data.obj.results[0].uuid}}
   register: se_authtoken
-  delegate_to: localhost
 
 - name: Avi SE | Autoregistration | Append the token to the docker environment variables.
   set_fact:

--- a/tasks/initial_data.yml
+++ b/tasks/initial_data.yml
@@ -15,14 +15,12 @@
     url: "https://{{ se_master_ctl_ip }}/api/initial-data"
     validate_certs: no
   register: initial_data
-  delegate_to: localhost
 
 - name: Avi SE | VMware | Initial Data | Get Controller cluster status
   uri:
     url: "https://{{ se_master_ctl_ip }}/api/cluster/status"
     validate_certs: no
   register: cluster_status
-  delegate_to: localhost
 
 - name: Avi SE | VMware | Initial Data | Set Controller version information
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,6 @@
     se_vmw_memory_reserved: '{{ se_vmw_memory_reserved }}'
     se_vmw_disk_size: '{{ se_vmw_disk_size }}'
     se_vmw_ovf_properties: '{{ se_vmw_ovf_properties }}'
-  delegate_to: localhost
 
 - name: Avi SE | Verify SE Deployment
   verify_se:
@@ -73,6 +72,5 @@
     se_vmw_vm_name: '{{ se_vmw_vm_name }}'
     se_vmw_mgmt_ip: '{{ se_vmw_mgmt_ip }}'
   register: verify_output
-  delegate_to: localhost
 
 - debug: msg={{ verify_output.msg }}

--- a/tasks/ova_deploy.yml
+++ b/tasks/ova_deploy.yml
@@ -18,7 +18,6 @@
         timeout: 600
         data:
           file_format: ova
-      delegate_to: localhost
   when: (not se_ova_status.stat.exists) or (se_vmw_ova_force_mode)
 
 - name: Avi SE | VMware | Verify SE image on Controller
@@ -28,7 +27,6 @@
 - name: Avi SE | VMware | Verify SE image on Local
   stat: path={{ se_vmw_ova_download_path }}/{{ se_vmw_ova_image_name }}
   register: se_ova_local_status
-  delegate_to: localhost
 
 - name: Avi SE | VMware | Image Deploy | Get SE image on Local
   avi_api_fileservice:
@@ -39,7 +37,6 @@
     upload: false
     path: seova
     file_path: '{{ se_vmw_ova_download_path }}/{{ se_vmw_ova_image_name }}'
-  delegate_to: localhost
   when: not se_ova_local_status.stat.exists
 
 - name: Avi SE | VMware | Verify SE image on Local
@@ -48,4 +45,3 @@
       register: se_ova_local_status
     - set_fact: se_vmw_ova_path={{ se_ova_local_status.stat.path }}
     - debug: msg='{{ se_vmw_ova_path }}'
-  delegate_to: localhost


### PR DESCRIPTION
We run AWX(ansible tower) in docker containers. We would like to skip re-image the contianer for every linux package dependency like in this case Ovftool from VMware. To make this possible I have to use 'delegate_to' on the whole role. And this pull request removes the use of 'delegate_to: localhost' on all sub-tasks. 
I did a run using the role from my Github branch after I removed this and it works like a charm!
Here is the task I run with some requirements:
```
  tasks:
    - name: Requirements for AVI
      pip:
        name:
          - avisdk
          - pyvmomi
          - requests_toolbelt
      become: true
      delegate_to: serverX.company.com
    
    - name: Deploy SE on VC
      import_role:
        name: avinetworks.avise_vmware
      vars:
        se_master_ctl_ip: "{{ avi_credentials.controller }}"
        se_master_ctl_username: "{{ avi_credentials.username }}"
        se_master_ctl_password: "{{ avi_credentials.password }}"
        se_cloud_name: NoAccess
        se_tenant: "{{ avi_tenant }}"
        se_group_name: "{{ avi_se_grp_name }}"
        ovftool_path: "{{ ovftool_run_path | default('/usr/bin/') }}"
        vcenter_host: "{{ vcsa_hostname }}"
        vcenter_user: "{{ vcsa_username }}"
        vcenter_password: "{{ vcsa_password }}"
        se_vmw_datacenter: "{{ vcsa_datacenter }}"
        se_vmw_cluster: "{{ vcsa_cluster }}"
        se_vmw_ovf_networks:
          'Management': Avi-SE-mgmt
          'Data Network 1': Avi-SE-Ext-Link
          'Data Network 2': Avi-SE-Int-Link
          'Data Network 3': Avi-SE-dmz
          'Data Network 4': Avi Internal
          'Data Network 5': Avi Internal
          'Data Network 6': Avi Internal
          'Data Network 7': Avi Internal
          'Data Network 8': Avi Internal
          'Data Network 9': Avi Internal
        se_vmw_vm_name: "{{ vcsa_vm_name }}"
        se_vmw_power_on: true
        se_vmw_vcenter_folder: infrastructure
        se_vmw_number_of_cpus: 2
        se_vmw_memory: 8192
        se_vmw_disk_size: 60
        se_vmw_mgmt_ip: "{{ se_mgmt_ip }}"
        se_vmw_mgmt_mask: 255.255.255.0
        se_vmw_default_gw: 10.0.0.1
        se_vmw_ovf_properties: 
          'avi.DNS.SE': "SERVERS:1.1.1.1,8.8.8.8"
      delegate_to: serverX.company.com
```